### PR TITLE
Add public songs page with cross-links to schedule

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -52,6 +52,7 @@ require_relative 'lib/routes/practices'
 require_relative 'lib/routes/api'
 require_relative 'lib/routes/mobile_api'
 require_relative 'lib/routes/public_schedule'
+require_relative 'lib/routes/public_songs'
 require_relative 'lib/routes/public_member'
 
 enable :static
@@ -115,6 +116,7 @@ use Routes::Practices
 use Routes::Api
 use Routes::MobileAPI
 use Routes::PublicSchedule
+use Routes::PublicSongs
 use Routes::PublicMember
 
 # Account creation code for user registration (required)

--- a/db/migrate/20260718114527_add_public_songs_to_bands.rb
+++ b/db/migrate/20260718114527_add_public_songs_to_bands.rb
@@ -1,0 +1,6 @@
+class AddPublicSongsToBands < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bands, :public_songs_enabled, :boolean, default: false
+    add_index :bands, :public_songs_enabled, name: 'index_bands_on_public_songs_enabled'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_12_194503) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_18_114527) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -24,6 +24,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_194503) do
     t.text "notes"
     t.bigint "owner_id"
     t.boolean "public_schedule_enabled", default: false
+    t.boolean "public_songs_enabled", default: false
     t.boolean "show_band_name", default: true, null: false
     t.string "slug"
     t.datetime "updated_at", null: false
@@ -32,6 +33,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_12_194503) do
     t.index ["name"], name: "index_bands_on_name", unique: true
     t.index ["owner_id"], name: "index_bands_on_owner_id"
     t.index ["public_schedule_enabled"], name: "index_bands_on_public_schedule_enabled"
+    t.index ["public_songs_enabled"], name: "index_bands_on_public_songs_enabled"
     t.index ["slug"], name: "index_bands_on_slug", unique: true
   end
 

--- a/lib/models/band.rb
+++ b/lib/models/band.rb
@@ -26,6 +26,10 @@ class Band < ActiveRecord::Base
     read_attribute(:public_schedule_enabled) == true
   end
 
+  def public_songs_enabled?
+    read_attribute(:public_songs_enabled) == true
+  end
+
   def owner?
     owners.exists?
   end

--- a/lib/routes/bands.rb
+++ b/lib/routes/bands.rb
@@ -518,6 +518,27 @@ class Routes::Bands < Sinatra::Base
     erb :edit_band
   end
 
+  # ============================================================================
+  # PUBLIC SONGS SETTINGS ROUTES
+  # ============================================================================
+
+  post '/bands/:id/public_songs_settings' do
+    require_login
+    @band = user_bands.includes(:user_bands, :owners).find(params[:id])
+    @user_bands_by_user_id = @band.user_bands.index_by(&:user_id)
+
+    # Any band member can configure public songs settings
+    unless @band.users.include?(current_user)
+      @public_songs_error = "You must be a member of this band to configure public songs settings"
+      return erb :edit_band
+    end
+
+    @band.update!(public_songs_enabled: params[:public_songs_enabled] == '1')
+
+    @public_songs_success = "Public songs settings updated successfully"
+    erb :edit_band
+  end
+
   private
 
   def _delete_band_logo(filename)

--- a/lib/routes/public_songs.rb
+++ b/lib/routes/public_songs.rb
@@ -1,0 +1,38 @@
+require 'sinatra/base'
+
+module Routes
+end
+
+class Routes::PublicSongs < Sinatra::Base
+  configure do
+    set :views, File.join(File.dirname(__FILE__), '..', '..', 'views')
+  end
+
+  helpers ApplicationHelpers
+
+  # ============================================================================
+  # PUBLIC SONGS ROUTES
+  # No authentication required - these are public endpoints
+  # ============================================================================
+
+  # GET /repertoire/:slug - Public HTML songs view
+  get '/repertoire/:slug' do
+    band = Band.find_by(slug: params[:slug])
+
+    if band.nil? || !band.public_songs_enabled?
+      return erb :public_songs_not_found, layout: :public_layout
+    end
+
+    @band = band
+    @view_by = params[:by] == 'artist' ? 'artist' : 'title'
+
+    songs = Song.active.ready_for_band(band)
+    @songs = if @view_by == 'artist'
+               songs.order(Arel.sql('LOWER(artist), LOWER(title)'))
+             else
+               songs.order(Arel.sql('LOWER(title)'))
+             end
+
+    erb :public_songs, layout: :public_layout
+  end
+end

--- a/spec/requests/public_schedule_spec.rb
+++ b/spec/requests/public_schedule_spec.rb
@@ -111,6 +111,22 @@ RSpec.describe 'Public Schedule Routes', type: :request do
         expect(last_response.body).to include('Test Venue')
         expect(last_response.body).to include('123 Main St')
       end
+
+      it 'links to the public songs page when it is enabled' do
+        band_with_gigs.update!(public_songs_enabled: true)
+
+        get "/schedule/#{band_with_gigs.slug}"
+
+        expect(last_response.body).to include("/repertoire/#{band_with_gigs.slug}")
+      end
+
+      it 'does not link to the public songs page when it is disabled' do
+        band_with_gigs.update!(public_songs_enabled: false)
+
+        get "/schedule/#{band_with_gigs.slug}"
+
+        expect(last_response.body).not_to include("/repertoire/#{band_with_gigs.slug}")
+      end
     end
 
     context 'when public schedule is disabled' do

--- a/spec/requests/public_songs_spec.rb
+++ b/spec/requests/public_songs_spec.rb
@@ -1,0 +1,194 @@
+require_relative '../spec_helper'
+
+RSpec.describe 'Public Songs Routes', type: :request do
+  let(:band) { create(:band, public_songs_enabled: true) }
+  let(:disabled_band) { create(:band, name: 'Private Band', public_songs_enabled: false) }
+
+  def add_song(band, title:, artist:, practicing: false)
+    song = create(:song, title: title, artist: artist)
+    band.songs << song
+    song.toggle_practice_for_band!(band) if practicing
+    song
+  end
+
+  describe 'GET /repertoire/:slug' do
+    context 'when public songs is enabled' do
+      it 'returns the public songs page' do
+        get "/repertoire/#{band.slug}"
+
+        expect(last_response).to be_ok
+      end
+
+      it 'displays the band name' do
+        band.update!(show_band_name: true)
+
+        get "/repertoire/#{band.slug}"
+
+        expect(last_response.body).to include(band.name)
+      end
+
+      it 'displays ready songs' do
+        add_song(band, title: 'Ready Song', artist: 'Ready Artist')
+
+        get "/repertoire/#{band.slug}"
+
+        expect(last_response.body).to include('Ready Song')
+        expect(last_response.body).to include('Ready Artist')
+      end
+
+      it 'excludes songs still being practiced' do
+        add_song(band, title: 'Practicing Song', artist: 'Practicing Artist', practicing: true)
+
+        get "/repertoire/#{band.slug}"
+
+        expect(last_response.body).not_to include('Practicing Song')
+      end
+
+      it 'excludes archived songs' do
+        song = add_song(band, title: 'Archived Song', artist: 'Archived Artist')
+        song.archive!
+
+        get "/repertoire/#{band.slug}"
+
+        expect(last_response.body).not_to include('Archived Song')
+      end
+
+      it 'shows empty state when band has no ready songs' do
+        get "/repertoire/#{band.slug}"
+
+        expect(last_response).to be_ok
+        expect(last_response.body).to include('No songs to show yet')
+      end
+
+      it 'lists songs alphabetically by title by default' do
+        add_song(band, title: 'Zebra Song', artist: 'Artist A')
+        add_song(band, title: 'Apple Song', artist: 'Artist B')
+
+        get "/repertoire/#{band.slug}"
+
+        body = last_response.body
+        expect(body.index('Apple Song')).to be < body.index('Zebra Song')
+      end
+
+      it 'lists songs grouped alphabetically by artist when requested' do
+        add_song(band, title: 'Song One', artist: 'Zebra Artist')
+        add_song(band, title: 'Song Two', artist: 'Apple Artist')
+
+        get "/repertoire/#{band.slug}?by=artist"
+
+        body = last_response.body
+        expect(body.index('Apple Artist')).to be < body.index('Zebra Artist')
+      end
+
+      it 'does not display a letter heading above song groups' do
+        add_song(band, title: 'Apple Song', artist: 'Artist A')
+
+        get "/repertoire/#{band.slug}"
+
+        expect(last_response.body).not_to include('letter-group')
+      end
+
+      it 'combines songs starting with the same letter into a single card' do
+        add_song(band, title: 'Apple Song', artist: 'Artist A')
+        add_song(band, title: 'Avocado Song', artist: 'Artist B')
+
+        get "/repertoire/#{band.slug}"
+
+        body = last_response.body
+        cards = body.split('<div class="song-card">')
+        matching_card = cards.find { |c| c.include?('Apple Song') }
+        expect(matching_card).to include('Avocado Song')
+      end
+
+      it 'splits songs with different starting letters into separate cards' do
+        add_song(band, title: 'Apple Song', artist: 'Artist A')
+        add_song(band, title: 'Banana Song', artist: 'Artist B')
+
+        get "/repertoire/#{band.slug}"
+
+        body = last_response.body
+        expect(body.scan('<div class="song-card">').count).to eq(2)
+      end
+
+      it 'combines artists sharing a first letter into a single card in artist view' do
+        add_song(band, title: 'Song One', artist: 'Apple Artist')
+        add_song(band, title: 'Song Two', artist: 'Avocado Artist')
+
+        get "/repertoire/#{band.slug}?by=artist"
+
+        body = last_response.body
+        expect(body.scan('<div class="song-card">').count).to eq(1)
+      end
+
+      it 'shows the letter badge only once per card, not per song' do
+        add_song(band, title: 'Apple Song', artist: 'Artist A')
+        add_song(band, title: 'Avocado Song', artist: 'Artist B')
+
+        get "/repertoire/#{band.slug}"
+
+        body = last_response.body
+        expect(body.scan('class="song-badge"').count).to eq(1)
+        expect(body).to include('>A<')
+      end
+
+      it 'links to the public schedule page when it is enabled' do
+        band.update!(public_schedule_enabled: true)
+
+        get "/repertoire/#{band.slug}"
+
+        expect(last_response.body).to include("/schedule/#{band.slug}")
+      end
+
+      it 'does not link to the public schedule page when it is disabled' do
+        band.update!(public_schedule_enabled: false)
+
+        get "/repertoire/#{band.slug}"
+
+        expect(last_response.body).not_to include("/schedule/#{band.slug}")
+      end
+    end
+
+    context 'when public songs is disabled' do
+      it 'returns 200 with not found page (not a 404 for security)' do
+        get "/repertoire/#{disabled_band.slug}"
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include('Songs Not Found')
+      end
+
+      it 'does not expose any band information' do
+        add_song(disabled_band, title: 'Secret Song', artist: 'Secret Artist')
+
+        get "/repertoire/#{disabled_band.slug}"
+
+        expect(last_response.body).not_to include('Secret Song')
+      end
+    end
+
+    context 'when band does not exist' do
+      it 'returns not found page' do
+        get '/repertoire/no-such-band'
+
+        expect(last_response.status).to eq(200)
+        expect(last_response.body).to include('Songs Not Found')
+      end
+    end
+  end
+
+  describe 'Security - No Authentication Required' do
+    it 'does not require authentication for public songs page' do
+      clear_cookies
+
+      get "/repertoire/#{band.slug}"
+
+      expect(last_response).to be_ok
+    end
+
+    it 'does not require Band Huddle session' do
+      get "/repertoire/#{band.slug}"
+
+      expect(last_response).to be_ok
+      expect(last_response.body).not_to include('Login')
+    end
+  end
+end

--- a/views/edit_band.erb
+++ b/views/edit_band.erb
@@ -289,6 +289,49 @@
         </form>
     </div>
 
+    <!-- Public Songs Section -->
+    <div class="card" style="margin-top: 30px; border: 1px solid #10b981; background: #f0fdf4;">
+        <h3>🎵 Public Songs</h3>
+        <p style="color: #666; margin-bottom: 20px;">
+            Make your band's song list visible to fans and followers without requiring them to log in.
+        </p>
+
+        <% if @public_songs_error %>
+            <div class="errors" style="margin-bottom: 20px;">
+                <p><%= @public_songs_error %></p>
+            </div>
+        <% end %>
+
+        <% if @public_songs_success %>
+            <div class="success" style="margin-bottom: 20px;">
+                <p><%= @public_songs_success %></p>
+            </div>
+        <% end %>
+
+        <form method="POST" action="/bands/<%= @band.id %>/public_songs_settings">
+            <div style="margin-bottom: 10px;">
+                <label style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
+                    <input type="checkbox"
+                           name="public_songs_enabled"
+                           value="1"
+                           <%= 'checked' if @band.public_songs_enabled? %>>
+                    <span style="font-weight: bold;">Enable Public Songs</span>
+                </label>
+                <p style="color: #666; margin-left: 30px; margin-bottom: 15px;">
+                    When enabled, songs your band is ready to play will be visible to anyone at:<br>
+                    <a href="/repertoire/<%= @band.slug %>" target="_blank" style="font-weight: 600; color: #10b981; text-decoration: none; word-break: break-all;" onmouseover="this.style.textDecoration='underline';" onmouseout="this.style.textDecoration='none';"><%= ENV['BASE_URL'] %>/repertoire/<%= @band.slug %></a>
+                </p>
+                <p style="margin: 0; font-size: 0.9rem; color: #666;">
+                    Songs currently marked as still being practiced are never shown publicly.
+                </p>
+            </div>
+
+            <div class="actions">
+                <button type="submit" class="btn btn-success">Save Public Songs Settings</button>
+            </div>
+        </form>
+    </div>
+
     <script>
         function togglePublicScheduleInfo(checkbox) {
             const infoDiv = document.getElementById('public-schedule-info');

--- a/views/public_layout.erb
+++ b/views/public_layout.erb
@@ -219,6 +219,117 @@
             color: #0f0c29;
         }
 
+        /* Cross-page nav (link between schedule and songs pages) */
+        .cross-page-nav {
+            text-align: center;
+            margin-bottom: 24px;
+        }
+
+        .cross-page-nav a {
+            display: inline-block;
+            color: rgba(255, 255, 255, 0.75);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 600;
+            padding: 6px 16px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            transition: color 0.15s, border-color 0.15s;
+        }
+
+        .cross-page-nav a:hover {
+            color: #ffd700;
+            border-color: #ffd700;
+        }
+
+        /* View toggle (songs page) */
+        .view-toggle {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+            margin-bottom: 30px;
+        }
+
+        .view-toggle-link {
+            color: rgba(255, 255, 255, 0.7);
+            text-decoration: none;
+            font-size: 0.9rem;
+            font-weight: 600;
+            padding: 8px 20px;
+            border-radius: 999px;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            background: rgba(255, 255, 255, 0.07);
+            transition: background 0.15s, color 0.15s;
+        }
+
+        .view-toggle-link:hover {
+            background: rgba(255, 255, 255, 0.14);
+            color: #fff;
+        }
+
+        .view-toggle-link.active {
+            background: #ffd700;
+            color: #0f0c29;
+            border-color: #ffd700;
+        }
+
+        /* Letter row: colored letter badge + card, badge shown once per starting letter */
+        .letter-row {
+            display: flex;
+            align-items: stretch;
+            gap: 0;
+            margin-bottom: 20px;
+            border-radius: 14px;
+        }
+
+        .song-badge {
+            flex-shrink: 0;
+            color: white;
+            border-radius: 12px 0 0 12px;
+            width: 60px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1.5rem;
+            font-weight: 900;
+        }
+
+        /* Song card: one card per starting letter, holding all its songs as rows */
+        .song-card {
+            flex: 1;
+            background: rgba(255, 255, 255, 0.07);
+            backdrop-filter: blur(14px);
+            -webkit-backdrop-filter: blur(14px);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            border-left: none;
+            border-radius: 0 12px 12px 0;
+            overflow: hidden;
+        }
+
+        .song-row {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 14px 22px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .song-row:last-child {
+            border-bottom: none;
+        }
+
+        .song-title {
+            font-weight: 600;
+            color: #fff;
+        }
+
+        .song-artist {
+            font-size: 0.9rem;
+            color: rgba(255, 255, 255, 0.55);
+            white-space: nowrap;
+        }
+
         .no-gigs {
             text-align: center;
             padding: 60px 20px;

--- a/views/public_schedule.erb
+++ b/views/public_schedule.erb
@@ -13,6 +13,12 @@
 
 <h1 class="page-heading">Upcoming Shows</h1>
 
+<% if @band.public_songs_enabled? %>
+    <div class="cross-page-nav">
+        <a href="/repertoire/<%= @band.slug %>">🎵 View Song List</a>
+    </div>
+<% end %>
+
 <% if @upcoming_gigs.any? %>
     <%
       _palette = [

--- a/views/public_songs.erb
+++ b/views/public_songs.erb
@@ -1,0 +1,64 @@
+<% if @band.logo_filename.present? || @band.show_band_name %>
+    <div class="band-header">
+        <% if @band.logo_filename.present? %>
+            <img src="/uploads/band_logos/<%= @band.logo_filename %>"
+                 alt="<%= h(@band.name) %>"
+                 fetchpriority="high">
+        <% end %>
+        <% if @band.show_band_name || !@band.logo_filename.present? %>
+            <div class="band-title"><%= h(@band.name) %></div>
+        <% end %>
+    </div>
+<% end %>
+
+<h1 class="page-heading">Songs</h1>
+
+<% if @band.public_schedule_enabled? %>
+    <div class="cross-page-nav">
+        <a href="/schedule/<%= @band.slug %>">📅 View Upcoming Shows</a>
+    </div>
+<% end %>
+
+<div class="view-toggle">
+    <a href="/repertoire/<%= @band.slug %>?by=title" class="view-toggle-link<%= ' active' if @view_by == 'title' %>">By Title</a>
+    <a href="/repertoire/<%= @band.slug %>?by=artist" class="view-toggle-link<%= ' active' if @view_by == 'artist' %>">By Artist</a>
+</div>
+
+<% if @songs.any? %>
+    <%
+      _group_field = @view_by == 'artist' ? :artist : :title
+      _letter_groups = @songs.group_by { |song| song.public_send(_group_field)[0].upcase }
+
+      _palette = [
+        { bg: '#c44d7a' },
+        { bg: '#c97030' },
+        { bg: '#6848c0' },
+        { bg: '#2a9e8a' },
+        { bg: '#b89020' },
+      ]
+      _last = nil
+      _letter_colors = _letter_groups.keys.each_with_object({}) do |letter, colors|
+        _last = (_palette - [_last]).sample
+        colors[letter] = _last
+      end
+    %>
+    <% _letter_groups.each do |letter, songs| %>
+        <div class="letter-row">
+            <div class="song-badge" style="background:<%= _letter_colors[letter][:bg] %>"><%= h(letter) %></div>
+            <div class="song-card">
+                <% songs.each do |song| %>
+                    <div class="song-row">
+                        <div class="song-title"><%= h(song.title) %></div>
+                        <div class="song-artist"><%= h(song.artist) %></div>
+                    </div>
+                <% end %>
+            </div>
+        </div>
+    <% end %>
+<% else %>
+    <div class="no-gigs">
+        <div class="no-gigs-icon">🎵</div>
+        <p>No songs to show yet.</p>
+        <p style="font-size: 0.9rem; margin-top: 10px;">Check back soon for updates!</p>
+    </div>
+<% end %>

--- a/views/public_songs_not_found.erb
+++ b/views/public_songs_not_found.erb
@@ -1,0 +1,17 @@
+<div class="card">
+    <div class="header">
+        <h1>🔍 Songs Not Found</h1>
+        <p>We couldn't find a public song list here.</p>
+    </div>
+
+    <div class="content">
+        <div class="no-gigs">
+            <div class="no-gigs-icon">😕</div>
+            <p>This song list may not be public yet, or the band doesn't exist.</p>
+            <p style="font-size: 0.9rem; margin-top: 10px;">
+                Bands can enable their public songs page in
+                <a href="/login" style="color: #667eea;">Band Huddle</a>.
+            </p>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- Adds an opt-in, no-login public songs page at `/repertoire/:slug` (mirrors the existing `/schedule/:slug` public schedule feature)
- Songs are sortable by title or artist, grouped into cards by first letter (colored letter badge shown once per card), and exclude songs still marked as being practiced or archived
- The public schedule and public songs pages now cross-link to each other when both are enabled for a band
- Adds a "🎵 Public Songs" toggle section to the band settings page

## Test plan
- [x] `rake db:migrate` applied cleanly to dev and test databases
- [x] `bundle exec rspec spec/requests/public_songs_spec.rb spec/requests/public_schedule_spec.rb` — 66 passed
- [x] Manually verified `/repertoire/:slug` renders the not-found page for missing/disabled bands
- [x] Manually verified server boots and route responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bands can enable or disable a public song repertoire from band settings.
  * Added a public repertoire page with sorting by title or artist.
  * Displays ready songs grouped alphabetically, with an empty-state message when none are available.
  * Public repertoire pages require no authentication and link to public schedules when enabled.
  * Added navigation between public schedules and repertoires.

* **Bug Fixes**
  * Restricted public repertoire access when the feature is disabled or the band cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->